### PR TITLE
query for no company name handled

### DIFF
--- a/app/src/main/java/directory/tripin/com/tripindirectory/newactivities/MainActivity1.java
+++ b/app/src/main/java/directory/tripin/com/tripindirectory/newactivities/MainActivity1.java
@@ -295,7 +295,7 @@ public class MainActivity1 extends AppCompatActivity implements NavigationView.O
         lottieAnimationView.setVisibility(View.VISIBLE);
 
         query = FirebaseFirestore.getInstance()
-                .collection("partners").orderBy("mCompanyName");
+                .collection("partners").orderBy("mCompanyName").whereGreaterThan("mCompanyName", "");
 
         if (!s.isEmpty()) {
             switch (searchTag) {

--- a/app/src/main/java/directory/tripin/com/tripindirectory/newactivities/PartnerDetailScrollingActivity.java
+++ b/app/src/main/java/directory/tripin/com/tripindirectory/newactivities/PartnerDetailScrollingActivity.java
@@ -498,7 +498,6 @@ public class PartnerDetailScrollingActivity extends AppCompatActivity implements
                 Address location = address.get(0);
                 location.getLatitude();
                 location.getLongitude();
-
                 p1 = new LatLng(location.getLatitude(), location.getLongitude() );
                 return p1;
             }

--- a/app/src/main/java/directory/tripin/com/tripindirectory/utils/TextUtils.java
+++ b/app/src/main/java/directory/tripin/com/tripindirectory/utils/TextUtils.java
@@ -26,6 +26,9 @@ public class TextUtils {
             if(Character.isSpaceChar(c)){
                 nextTitleCase = true;
             }
+            if(c=='.'){
+                nextTitleCase = true;
+            }
             if(nextTitleCase && !Character.isSpaceChar(c) ){
                 cc = (char) (c & 0x5f);//to upper case
                 nextTitleCase = false;


### PR DESCRIPTION
wil not show empty cards now